### PR TITLE
feat(extra-metadata): add AST ID to recursiveFunctions metadata

### DIFF
--- a/libsolidity/codegen/ExtraMetadata.cpp
+++ b/libsolidity/codegen/ExtraMetadata.cpp
@@ -140,6 +140,7 @@ Json ExtraMetadataRecorder::run(ContractDefinition const& _contract)
 
 			Json func = Json::object();
 			func["name"] = fn->name();
+			func["astId"] = fn->id();
 
 			// Assembly::new[Push]Tag() asserts that the tag is 32 bits
 			auto tagNum = tag.data().convert_to<uint32_t>();


### PR DESCRIPTION
## Summary
- Add `astId` field to function entries in `recursiveFunctions` extra metadata
- This enables solx to look up function definitions by AST node ID for accurate DWARF debug info generation in the EVMLA (legacy assembly) pipeline

## Context
When generating debug info for the EVMLA pipeline, solx needs to map function tags to their source locations. Previously, we only had function names, which can be ambiguous across contracts/interfaces (e.g., `approve` in both `ERC20.sol` and `IUniswapV2Pair.sol`). With the AST ID, solx can directly look up the correct function definition.

## Test plan
- [x] Build solc with change
- [x] Verify `astId` appears in extra metadata output
- [x] Verify solx correctly uses AST ID for debug info generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)