### PR TITLE
fix: add boost to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ emscripten_build/
 /.cproject
 /.project
 
+# Boost
+/boost/
+/boost_*/
+boost_*.tar.gz
+
 # OS specific local files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Add gitignore entries for boost directories and tarballs that are generated locally during the solc build process (`boost/`, `boost_*/`, `boost_*.tar.gz`) by the `solx-dev` tool.