### PR TITLE
[mlir] Use DefaultThreadPool for cross-platform threading

### DIFF
--- a/libsolidity/codegen/mlir/SolidityToMLIR.cpp
+++ b/libsolidity/codegen/mlir/SolidityToMLIR.cpp
@@ -3208,7 +3208,7 @@ static void loadDialects(mlir::MLIRContext &ctx) {
 }
 
 bool CompilerStack::runMlirPipeline() {
-  llvm::StdThreadPool threadPool;
+  llvm::DefaultThreadPool threadPool;
   // For sync'ing the output collection.
   std::mutex outMtx;
   // For sync'ing the error printing.


### PR DESCRIPTION
Replace `llvm::StdThreadPool`, which is only defined when LLVM is built with `LLVM_ENABLE_THREADS=ON`, with `llvm::DefaultThreadPool`. The latter aliases `StdThreadPool` when threads are enabled and falls back to `SingleThreadExecutor` otherwise — both implement `ThreadPoolInterface`, so the call site is unchanged.

LLVM's CMake configure on Windows MinGW probes `HAVE_BUILTIN_THREAD_POINTER`, sees it fail, and prints `-- Threads disabled.`, leaving `LLVM_ENABLE_THREADS=Off` baked into the generated `llvm-config.h`. Compiling `SolidityToMLIR.cpp` against those headers fails with:

```
error: no type named 'StdThreadPool' in namespace 'llvm'
  llvm::StdThreadPool threadPool;
```

Linux and macOS were unaffected because their LLVM builds keep threads enabled. Caught on the Windows leg of solx's slang-tests workflow once it started building solc with `--enable-mlir`.