### PR TITLE
fix: include <cstdint> in ASTForward.h for GCC 16

### DIFF
--- a/libsolidity/ast/ASTForward.h
+++ b/libsolidity/ast/ASTForward.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Our Windows CI now builds solc with the MinGW GCC 16 toolchain, whose libstdc++ no longer transitively pulls in `<cstdint>`. `ASTForward.h` uses `int64_t` without including it, so the build fails with `unknown type name 'int64_t'`; this adds the missing `#include <cstdint>`.
