### PR TITLE
fix: add boost to .gitignore (#111)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ emscripten_build/
 /.cproject
 /.project
 
+# Boost
+/boost/
+/boost_*/
+boost_*.tar.gz
+
 # OS specific local files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Ignore boost directories and tarballs that are generated locally during the solc build process.

(cherry picked from commit 2511f9442f23845e49a1663142412da6561ba12b)

Done to help with https://github.com/NomicFoundation/solx/pull/525