### PR TITLE
fix: mark CRLF test fixtures -text so autocrlf checkouts stay clean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.sol linguist-language=Solidity
+
+# Deliberately-CRLF fixtures: no eol conversion, or autocrlf checkouts see a perpetually dirty tree and builds get stamped `.mod`.
+test/libsolidity/syntaxTests/license/license_crlf_endings.sol -text
+test/scripts/fixtures/smt_contract_with_crlf_newlines.sol -text


### PR DESCRIPTION
Based on an issue I found in the release., where CRLF files get changed during git for Windows, which downstream causes a "modified" release on Windows. 

See also https://github.com/NomicFoundation/solx/pull/565.

# Claude summary
On Windows (autocrlf), the two deliberately-CRLF-committed fixtures never round-trip the clean filter, so `git diff HEAD` is always non-empty and buildinfo.cmake stamps every build `.mod` ("built from modified sources"), diverging contract metadata and CBOR trailers from other platforms. Disabling eol conversion for exactly these files keeps their CRLF content byte-identical (which is what they test) and lets the dirty check pass honestly. CI is already covered by commit_hash.txt (solx#565); this fixes local Windows dev builds and is upstream-able.