### PR TITLE
Add settings.legacyAssemblyAsString for memory-lean assembly output

### DIFF
--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -430,7 +430,7 @@ std::optional<Json> checkAuxiliaryInputKeys(Json const& _input)
 
 std::optional<Json> checkSettingsKeys(Json const& _input)
 {
-	static std::set<std::string> keys{"debug", "evmVersion", "eofVersion", "libraries", "metadata", "modelChecker", "optimizer", "outputSelection", "remappings", "stopAfter", "viaIR"};
+	static std::set<std::string> keys{"debug", "evmVersion", "eofVersion", "legacyAssemblyAsString", "libraries", "metadata", "modelChecker", "optimizer", "outputSelection", "remappings", "stopAfter", "viaIR"};
 	return checkKeys(_input, keys, "settings");
 }
 
@@ -852,6 +852,13 @@ std::variant<StandardCompiler::InputsAndSettings, Json> StandardCompiler::parseI
 		if (!settings["viaIR"].is_boolean())
 			return formatFatalError(Error::Type::JSONError, "\"settings.viaIR\" must be a Boolean.");
 		ret.viaIR = settings["viaIR"].get<bool>();
+	}
+
+	if (settings.contains("legacyAssemblyAsString"))
+	{
+		if (!settings["legacyAssemblyAsString"].is_boolean())
+			return formatFatalError(Error::Type::JSONError, "\"settings.legacyAssemblyAsString\" must be a Boolean.");
+		ret.legacyAssemblyAsString = settings["legacyAssemblyAsString"].get<bool>();
 	}
 
 	if (settings.contains("evmVersion"))
@@ -1583,7 +1590,16 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 		if (compilationSuccess && isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.assembly", wildcardMatchesExperimental))
 			evmData["assembly"] = compilerStack.assemblyString(contractName, sourceList);
 		if (compilationSuccess && isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.legacyAssembly", wildcardMatchesExperimental))
-			evmData["legacyAssembly"] = compilerStack.assemblyJSON(contractName);
+		{
+			// Keeping every contract's assembly JSON tree in the response object until the final
+			// dump dominates peak memory on large projects; as a string, the tree is dropped here.
+			// Contracts without assembly (e.g. interfaces) keep emitting a JSON null.
+			Json assemblyJson = compilerStack.assemblyJSON(contractName);
+			if (_inputsAndSettings.legacyAssemblyAsString && !assemblyJson.is_null())
+				evmData["legacyAssembly"] = assemblyJson.dump();
+			else
+				evmData["legacyAssembly"] = std::move(assemblyJson);
+		}
 		if (isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.methodIdentifiers", wildcardMatchesExperimental))
 			evmData["methodIdentifiers"] = compilerStack.interfaceSymbols(contractName)["methods"];
 		if (compilationSuccess && isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.gasEstimates", wildcardMatchesExperimental))

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -430,7 +430,7 @@ std::optional<Json> checkAuxiliaryInputKeys(Json const& _input)
 
 std::optional<Json> checkSettingsKeys(Json const& _input)
 {
-	static std::set<std::string> keys{"debug", "evmVersion", "eofVersion", "legacyAssemblyAsString", "libraries", "metadata", "modelChecker", "optimizer", "outputSelection", "remappings", "stopAfter", "viaIR"};
+	static std::set<std::string> keys{"debug", "evmVersion", "eofVersion", "libraries", "metadata", "modelChecker", "optimizer", "outputSelection", "remappings", "stopAfter", "viaIR"};
 	return checkKeys(_input, keys, "settings");
 }
 
@@ -852,13 +852,6 @@ std::variant<StandardCompiler::InputsAndSettings, Json> StandardCompiler::parseI
 		if (!settings["viaIR"].is_boolean())
 			return formatFatalError(Error::Type::JSONError, "\"settings.viaIR\" must be a Boolean.");
 		ret.viaIR = settings["viaIR"].get<bool>();
-	}
-
-	if (settings.contains("legacyAssemblyAsString"))
-	{
-		if (!settings["legacyAssemblyAsString"].is_boolean())
-			return formatFatalError(Error::Type::JSONError, "\"settings.legacyAssemblyAsString\" must be a Boolean.");
-		ret.legacyAssemblyAsString = settings["legacyAssemblyAsString"].get<bool>();
 	}
 
 	if (settings.contains("evmVersion"))
@@ -1592,13 +1585,15 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 		if (compilationSuccess && isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.legacyAssembly", wildcardMatchesExperimental))
 		{
 			// Keeping every contract's assembly JSON tree in the response object until the final
-			// dump dominates peak memory on large projects; as a string, the tree is dropped here.
+			// dump dominates peak memory on large projects, so the assembly is emitted as a
+			// pre-serialized compact string and the tree is dropped here. This diverges from
+			// upstream solc output on purpose: solx, the sole consumer, parses it back.
 			// Contracts without assembly (e.g. interfaces) keep emitting a JSON null.
 			Json assemblyJson = compilerStack.assemblyJSON(contractName);
-			if (_inputsAndSettings.legacyAssemblyAsString && !assemblyJson.is_null())
-				evmData["legacyAssembly"] = assemblyJson.dump();
-			else
+			if (assemblyJson.is_null())
 				evmData["legacyAssembly"] = std::move(assemblyJson);
+			else
+				evmData["legacyAssembly"] = assemblyJson.dump();
 		}
 		if (isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.methodIdentifiers", wildcardMatchesExperimental))
 			evmData["methodIdentifiers"] = compilerStack.interfaceSymbols(contractName)["methods"];

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -89,6 +89,7 @@ private:
 		Json outputSelection;
 		ModelCheckerSettings modelCheckerSettings = ModelCheckerSettings{};
 		bool viaIR = false;
+		bool legacyAssemblyAsString = false;
 	};
 
 	/// Parses the input json (and potentially invokes the read callback) and either returns

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -89,7 +89,6 @@ private:
 		Json outputSelection;
 		ModelCheckerSettings modelCheckerSettings = ModelCheckerSettings{};
 		bool viaIR = false;
-		bool legacyAssemblyAsString = false;
 	};
 
 	/// Parses the input json (and potentially invokes the read callback) and either returns

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -493,6 +493,81 @@ BOOST_AUTO_TEST_CASE(optimizer_runs_not_an_unsigned_number)
 	BOOST_CHECK(containsError(result, "JSONError", "The \"runs\" setting must be an unsigned number."));
 }
 
+BOOST_AUTO_TEST_CASE(legacy_assembly_as_string_not_boolean)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity",
+		"settings": {
+			"legacyAssemblyAsString": 1
+		},
+		"sources": {
+			"empty": {
+				"content": ""
+			}
+		}
+	}
+	)";
+	Json result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "\"settings.legacyAssemblyAsString\" must be a Boolean."));
+}
+
+BOOST_AUTO_TEST_CASE(legacy_assembly_as_string)
+{
+	char const* inputFlagOff = R"(
+	{
+		"language": "Solidity",
+		"sources": {
+			"fileA": {
+				"content": "interface I { function f() external; } contract A is I { function f() external {} }"
+			}
+		},
+		"settings": {
+			"legacyAssemblyAsString": false,
+			"outputSelection": {
+				"fileA": {
+					"*": [ "evm.legacyAssembly" ]
+				}
+			}
+		}
+	}
+	)";
+	char const* inputFlagOn = R"(
+	{
+		"language": "Solidity",
+		"sources": {
+			"fileA": {
+				"content": "interface I { function f() external; } contract A is I { function f() external {} }"
+			}
+		},
+		"settings": {
+			"legacyAssemblyAsString": true,
+			"outputSelection": {
+				"fileA": {
+					"*": [ "evm.legacyAssembly" ]
+				}
+			}
+		}
+	}
+	)";
+	Json objectResult = compile(inputFlagOff);
+	Json stringResult = compile(inputFlagOn);
+	BOOST_CHECK(containsAtMostWarnings(objectResult));
+	BOOST_CHECK(containsAtMostWarnings(stringResult));
+
+	Json objectAssembly = getContractResult(objectResult, "fileA", "A")["evm"]["legacyAssembly"];
+	Json stringAssembly = getContractResult(stringResult, "fileA", "A")["evm"]["legacyAssembly"];
+	BOOST_REQUIRE(objectAssembly.is_object());
+	BOOST_REQUIRE(stringAssembly.is_string());
+	Json reparsedAssembly;
+	BOOST_REQUIRE(util::jsonParseStrict(stringAssembly.get<std::string>(), reparsedAssembly));
+	BOOST_CHECK(reparsedAssembly == objectAssembly);
+
+	// Contracts without assembly keep emitting a JSON null instead of the string "null".
+	BOOST_CHECK(getContractResult(objectResult, "fileA", "I")["evm"]["legacyAssembly"].is_null());
+	BOOST_CHECK(getContractResult(stringResult, "fileA", "I")["evm"]["legacyAssembly"].is_null());
+}
+
 BOOST_AUTO_TEST_CASE(basic_compilation)
 {
 	char const* input = R"(

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -493,79 +493,37 @@ BOOST_AUTO_TEST_CASE(optimizer_runs_not_an_unsigned_number)
 	BOOST_CHECK(containsError(result, "JSONError", "The \"runs\" setting must be an unsigned number."));
 }
 
-BOOST_AUTO_TEST_CASE(legacy_assembly_as_string_not_boolean)
+BOOST_AUTO_TEST_CASE(legacy_assembly_emitted_as_string)
 {
 	char const* input = R"(
 	{
 		"language": "Solidity",
-		"settings": {
-			"legacyAssemblyAsString": 1
-		},
 		"sources": {
-			"empty": {
-				"content": ""
+			"fileA": {
+				"content": "interface I { function f() external; } contract A is I { function f() external {} }"
+			}
+		},
+		"settings": {
+			"outputSelection": {
+				"fileA": {
+					"*": [ "evm.legacyAssembly" ]
+				}
 			}
 		}
 	}
 	)";
 	Json result = compile(input);
-	BOOST_CHECK(containsError(result, "JSONError", "\"settings.legacyAssemblyAsString\" must be a Boolean."));
-}
+	BOOST_CHECK(containsAtMostWarnings(result));
 
-BOOST_AUTO_TEST_CASE(legacy_assembly_as_string)
-{
-	char const* inputFlagOff = R"(
-	{
-		"language": "Solidity",
-		"sources": {
-			"fileA": {
-				"content": "interface I { function f() external; } contract A is I { function f() external {} }"
-			}
-		},
-		"settings": {
-			"legacyAssemblyAsString": false,
-			"outputSelection": {
-				"fileA": {
-					"*": [ "evm.legacyAssembly" ]
-				}
-			}
-		}
-	}
-	)";
-	char const* inputFlagOn = R"(
-	{
-		"language": "Solidity",
-		"sources": {
-			"fileA": {
-				"content": "interface I { function f() external; } contract A is I { function f() external {} }"
-			}
-		},
-		"settings": {
-			"legacyAssemblyAsString": true,
-			"outputSelection": {
-				"fileA": {
-					"*": [ "evm.legacyAssembly" ]
-				}
-			}
-		}
-	}
-	)";
-	Json objectResult = compile(inputFlagOff);
-	Json stringResult = compile(inputFlagOn);
-	BOOST_CHECK(containsAtMostWarnings(objectResult));
-	BOOST_CHECK(containsAtMostWarnings(stringResult));
-
-	Json objectAssembly = getContractResult(objectResult, "fileA", "A")["evm"]["legacyAssembly"];
-	Json stringAssembly = getContractResult(stringResult, "fileA", "A")["evm"]["legacyAssembly"];
-	BOOST_REQUIRE(objectAssembly.is_object());
+	Json stringAssembly = getContractResult(result, "fileA", "A")["evm"]["legacyAssembly"];
 	BOOST_REQUIRE(stringAssembly.is_string());
 	Json reparsedAssembly;
 	BOOST_REQUIRE(util::jsonParseStrict(stringAssembly.get<std::string>(), reparsedAssembly));
-	BOOST_CHECK(reparsedAssembly == objectAssembly);
+	BOOST_REQUIRE(reparsedAssembly.is_object());
+	BOOST_CHECK(reparsedAssembly[".code"].is_array());
 
 	// Contracts without assembly keep emitting a JSON null instead of the string "null".
-	BOOST_CHECK(getContractResult(objectResult, "fileA", "I")["evm"]["legacyAssembly"].is_null());
-	BOOST_CHECK(getContractResult(stringResult, "fileA", "I")["evm"]["legacyAssembly"].is_null());
+	BOOST_CHECK(getContractResult(result, "fileA", "I")["evm"]["legacyAssembly"].is_null());
 }
 
 BOOST_AUTO_TEST_CASE(basic_compilation)
@@ -633,10 +591,14 @@ BOOST_AUTO_TEST_CASE(basic_compilation)
 	);
 	// Lets take the top level `.code` section (the "deployer code"), that should expose most of the features of
 	// the assembly JSON. What we want to check here is Operation, Push, PushTag, PushSub, PushSubSize and Tag.
-	BOOST_CHECK(contract["evm"]["legacyAssembly"].is_object());
-	BOOST_CHECK(contract["evm"]["legacyAssembly"][".code"].is_array());
+	// The assembly is emitted as a pre-serialized string, so it is parsed back first.
+	BOOST_REQUIRE(contract["evm"]["legacyAssembly"].is_string());
+	Json legacyAssembly;
+	BOOST_REQUIRE(util::jsonParseStrict(contract["evm"]["legacyAssembly"].get<std::string>(), legacyAssembly));
+	BOOST_CHECK(legacyAssembly.is_object());
+	BOOST_CHECK(legacyAssembly[".code"].is_array());
 	BOOST_CHECK_EQUAL(
-		util::jsonCompactPrint(contract["evm"]["legacyAssembly"][".code"]),
+		util::jsonCompactPrint(legacyAssembly[".code"]),
 		"[{\"begin\":0,\"end\":14,\"name\":\"PUSH\",\"source\":0,\"value\":\"80\"},"
 		"{\"begin\":0,\"end\":14,\"name\":\"PUSH\",\"source\":0,\"value\":\"40\"},"
 		"{\"begin\":0,\"end\":14,\"name\":\"MSTORE\",\"source\":0},"


### PR DESCRIPTION
https://github.com/NomicFoundation/hardhat/pull/8521 found a memory regression in using Hardhat 3 + solx versus Hardhat 3 + solc. Fix is making `evm.legacyAssembly` more efficient. Please review strictly, as this is Claude driven. 

# Claude summary
## What

`StandardCompiler` now emits each contract's `evm.legacyAssembly` as a pre-serialized compact JSON string instead of a JSON object — unconditionally (per review feedback the earlier opt-in `settings.legacyAssemblyAsString` is dropped again in the last commit: solx is the sole consumer and is statically linked and version-locked with this library, so the format needs no negotiation). Contracts without assembly (interfaces, abstract contracts) keep emitting JSON `null`. The `EVMAssembly` import path keeps the object form — it round-trips imported assembly JSON for tooling and has no whole-project memory profile.

## Why

With `evm.legacyAssembly` selected for a whole project — which solx does on every legacy-mode compile, since the assembly JSON is its input IR — `StandardCompiler` keeps every contract's assembly tree alive in the response object until the single final dump. Each tree also embeds full copies of all dependency assemblies (`Assembly::assemblyJSON` recursion), so on test-heavy projects this dominates peak memory. Emitting a string lets each tree die as soon as the contract's output is built.

First observed in the hardhat solx compile benchmarks (NomicFoundation/hardhat#8521), where the Graph Horizon legacy cell peaked at ~10 GB RSS — enough to OOM a 16 GB CI runner on a repo with ~2× its test surface.

Measured on Graph Horizon (`packages/horizon` of graphprotocol-contracts, 240 sources, 91 Foundry test units, solc 0.8.34, optimizer runs 100, cancun, non-via-IR), 16-core Linux:

| run | object emission | string emission |
|---|---|---|
| standalone `solc --standard-json`, solx-style output selection | 9.51 GB | **2.79 GB** |
| solx end-to-end (with the companion solx change) | 9.56 GB / ~48 s | **3.94 GB / ~33 s** |

The wall-time drop is free: building the intermediate `nlohmann` trees was pure overhead.

## Output invariance

- Flag-toggle control while the setting still existed (same binary, off vs on, consumed through solx): the final solx standard JSON output was `cmp`-byte-identical on both the legacy and via-IR replays of the Horizon corpus. The final commit only makes that same emission path unconditional; re-running both replays against the flagged build shows zero structural differences — the only changed bytes are the CBOR metadata-hash tails that embed the solc commit hash, which change on every commit of this repo by construction.
- Direct comparison of string-form vs object-form solc output: all 165 emitted assemblies parse back deep-equal to the object form, the 88 `null`s are preserved, and the rest of the response is identical.

## Testing

- `StandardCompiler` unit tests: string emission reparses to an object with the expected `.code` shape, `null` is preserved for the interface in the same source, and `basic_compilation`'s assembly assertions are updated to parse the string. Verified red on the parent commit and green here.
- This repo currently has no CI that runs soltest, so locally: configure with `-DTESTS=ON`, then `ETH_EVMONE=<path>/libevmone.so ./build/test/soltest --run_test=StandardCompiler -- --testpath test` (a prebuilt evmone 0.16.0 works; soltest aborts at startup without one).
- The suite has five pre-existing failures on this branch's parent (`optimizer_settings_default_enabled`, `optimizer_settings_details_different`, `optimizer_settings_details_exactly_as_default_disabled`, `use_stack_optimization`, `dependency_tracking_of_abstract_contract`) — identical before and after this change; expected fallout of the legacy revision's optimiser no-op.
- Continuous end-to-end coverage arrives with the mirroring solx PR: solx CI's standard-JSON CLI tests and solx-tester's EVMLA modes then exercise the string path on every run.

## Notes for review

- The `null` guard matters: `Json{}.dump()` would emit the *string* `"null"`, which downstream `Option`-based consumers would try to parse as an assembly. Covered by a test and by Horizon (88 of its 253 contract outputs are assembly-less).
- The standard JSON output format now deliberately diverges from upstream solc for this artifact; only solx consumes it.
- The mirroring solx PR: NomicFoundation/solx#662 (string parsing in `LegacyAssembly::materialize` + temporary submodule pin to this branch, to be re-pinned after this merges).
- Follow-up candidates, deliberately not in this PR: emitting dependency *references* instead of embedded assembly copies (shrinks the remaining ~440 MB of assembly text and solx's parse cost), and releasing assemblies during codegen (minor now — the compile phase peaks at ~2.4 GB once tree retention is gone).
